### PR TITLE
Fix typo in web.manifest

### DIFF
--- a/frontend/src/static/app/site.webmanifest
+++ b/frontend/src/static/app/site.webmanifest
@@ -1,6 +1,6 @@
 {
-    "name": "Alebdo",
-    "short_name": "Alebdo",
+    "name": "Albedo",
+    "short_name": "Albedo",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
web.manifest file has the "name" and "short_name" listed as "Alebdo" instead of "Albedo"